### PR TITLE
For Issue #24:

### DIFF
--- a/src/main/java/amqp/spring/camel/component/SpringAMQPConsumer.java
+++ b/src/main/java/amqp/spring/camel/component/SpringAMQPConsumer.java
@@ -117,6 +117,7 @@ public class SpringAMQPConsumer extends DefaultConsumer implements ConnectionLis
             this.listenerContainer.setQueueNames(endpoint.getQueueName());
             this.listenerContainer.setConcurrentConsumers(endpoint.getConcurrentConsumers());
             this.listenerContainer.setPrefetchCount(endpoint.getPrefetchCount());
+            this.listenerContainer.setAcknowledgeMode(endpoint.getAcknowledgeMode());
 
             //Set error handling (send it to Camel)
             this.listenerContainer.setErrorHandler(getErrorHandler());
@@ -129,7 +130,6 @@ public class SpringAMQPConsumer extends DefaultConsumer implements ConnectionLis
 
             //Transactions are currently not supported
             this.listenerContainer.setChannelTransacted(false);
-            this.listenerContainer.setAcknowledgeMode(AcknowledgeMode.NONE);
         }
 
         public void start() {

--- a/src/main/java/amqp/spring/camel/component/SpringAMQPEndpoint.java
+++ b/src/main/java/amqp/spring/camel/component/SpringAMQPEndpoint.java
@@ -8,6 +8,7 @@ import org.apache.camel.*;
 import org.apache.camel.impl.DefaultEndpoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.DirectExchange;
@@ -47,6 +48,7 @@ public class SpringAMQPEndpoint extends DefaultEndpoint {
     int concurrentConsumers = 1;
     int prefetchCount = 1;
     Integer timeToLive = null;
+    AcknowledgeMode acknowledgeMode = AcknowledgeMode.NONE;
     
     //The second and third parameters to the URI can be interchangable based on the context.
     //Place them here until we determine if we're a consumer or producer.
@@ -194,6 +196,14 @@ public class SpringAMQPEndpoint extends DefaultEndpoint {
 
     public void setAutodelete(boolean autodelete) {
         this.autodelete = autodelete;
+    }
+
+    public void setAcknowledgeMode(String acknowledgeMode) {
+        this.acknowledgeMode = AcknowledgeMode.valueOf(acknowledgeMode.toUpperCase());
+    }
+
+    public AcknowledgeMode getAcknowledgeMode() {
+        return this.acknowledgeMode;
     }
 
     public boolean isDurable() {


### PR DESCRIPTION
This pull request allows support for acknowledgeMode to be specified in the url so that users of this library can specify the acknowledge they need.  This is a requirement if prefetchCount is to be honored as well. 

There's a test added in src/test/java/amqp/spring/camel/component/SpringAMQPConsumerTest.java that validates that specifying prefetch + acknowledge mode doesn't cause the route to fail to load that processing of a couple of messages still works with those parameters set on the component 
