### PR TITLE
Introduced a field in SpringAMQPComponent to allow overriding default scheme

### DIFF
--- a/src/main/java/amqp/spring/camel/component/SpringAMQPComponent.java
+++ b/src/main/java/amqp/spring/camel/component/SpringAMQPComponent.java
@@ -5,6 +5,7 @@
 package amqp.spring.camel.component;
 
 import java.util.Map;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.impl.DefaultComponent;
@@ -19,42 +20,54 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 
 public class SpringAMQPComponent extends DefaultComponent {
     private static transient final Logger LOG = LoggerFactory.getLogger(SpringAMQPComponent.class);
-    
+
+    public static final String DEFAULT_SCHEME = "spring-amqp";
+    protected String scheme = DEFAULT_SCHEME;
+
     protected ConnectionFactory connectionFactory;
     protected AmqpTemplate amqpTemplate;
     protected AmqpAdmin amqpAdministration;
     public static final String ROUTING_KEY_HEADER = "ROUTING_KEY";
-    
+
     public SpringAMQPComponent() {
         this.connectionFactory = new CachingConnectionFactory();
     }
-    
+
     public SpringAMQPComponent(CamelContext context) {
         super(context);
-        
-        //Attempt to load a connection factory from the registry
-        if(this.connectionFactory == null) {
-            Map<String, ConnectionFactory> factories = context.getRegistry().lookupByType(ConnectionFactory.class);
-            if(factories != null && ! factories.isEmpty()) {
+
+        // Attempt to load a connection factory from the registry
+        if (this.connectionFactory == null) {
+            Map < String, ConnectionFactory > factories = context.getRegistry().lookupByType(ConnectionFactory.class);
+            if (factories != null && !factories.isEmpty()) {
                 this.connectionFactory = factories.values().iterator().next();
                 LOG.info("Found AMQP ConnectionFactory in registry for {}", this.connectionFactory.getHost());
             }
         }
-        
-        if(this.connectionFactory == null) {
+
+        if (this.connectionFactory == null) {
             LOG.error("Cannot find a connection factory!");
         }
     }
-    
+
     public SpringAMQPComponent(ConnectionFactory connectionFactory) {
         this.connectionFactory = connectionFactory;
     }
 
     @Override
-    protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
-        SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(this, uri, remaining, getAmqpTemplate(), getAmqpAdministration());
+    protected Endpoint createEndpoint(String uri, String remaining, Map < String, Object > parameters) throws Exception {
+        SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(this, uri, remaining, getAmqpTemplate(),
+                getAmqpAdministration());
         setProperties(endpoint, parameters);
         return endpoint;
+    }
+
+    public String getScheme() {
+        return scheme;
+    }
+
+    public void setScheme(String scheme) {
+        this.scheme = scheme;
     }
 
     public ConnectionFactory getConnectionFactory() {
@@ -66,21 +79,21 @@ public class SpringAMQPComponent extends DefaultComponent {
     }
 
     public AmqpAdmin getAmqpAdministration() {
-        if(this.amqpAdministration == null && getCamelContext() != null && getCamelContext().getRegistry() != null) {
-            //Attempt to load an administration connection from the registry
-            Map<String, AmqpAdmin> factories = getCamelContext().getRegistry().lookupByType(AmqpAdmin.class);
-            if(factories != null && ! factories.isEmpty()) {
+        if (this.amqpAdministration == null && getCamelContext() != null && getCamelContext().getRegistry() != null) {
+            // Attempt to load an administration connection from the registry
+            Map < String, AmqpAdmin > factories = getCamelContext().getRegistry().lookupByType(AmqpAdmin.class);
+            if (factories != null && !factories.isEmpty()) {
                 this.amqpAdministration = factories.values().iterator().next();
                 LOG.info("Found AMQP Administrator in registry");
             }
         }
-        
-        if(this.amqpAdministration == null) {
-            //Attempt to construct an AMQP Adminstration instance
+
+        if (this.amqpAdministration == null) {
+            // Attempt to construct an AMQP Adminstration instance
             this.amqpAdministration = new RabbitAdmin(this.connectionFactory);
             LOG.info("Created new AMQP Administration instance");
         }
-        
+
         return this.amqpAdministration;
     }
 
@@ -89,30 +102,31 @@ public class SpringAMQPComponent extends DefaultComponent {
     }
 
     public AmqpTemplate getAmqpTemplate() {
-        if(this.amqpTemplate == null && getCamelContext() != null && getCamelContext().getRegistry() != null) {
-            //Attempt to load an AMQP template from the registry
-            Map<String, AmqpTemplate> factories = getCamelContext().getRegistry().lookupByType(AmqpTemplate.class);
-            if(factories != null && ! factories.isEmpty()) {
+        if (this.amqpTemplate == null && getCamelContext() != null && getCamelContext().getRegistry() != null) {
+            // Attempt to load an AMQP template from the registry
+            Map < String, AmqpTemplate > factories = getCamelContext().getRegistry().lookupByType(AmqpTemplate.class);
+            if (factories != null && !factories.isEmpty()) {
                 this.amqpTemplate = factories.values().iterator().next();
                 LOG.info("Found AMQP Template in registry");
             }
         }
-        
-        if(this.amqpTemplate == null) {
-            //Attempt to construct an AMQP template
+
+        if (this.amqpTemplate == null) {
+            // Attempt to construct an AMQP template
             this.amqpTemplate = new RabbitTemplate(this.connectionFactory);
             LOG.info("Created new AMQP Template");
         }
-        
+
         return this.amqpTemplate;
     }
 
     public void setAmqpTemplate(AmqpTemplate amqpTemplate) {
         this.amqpTemplate = amqpTemplate;
-    } 
-    
+    }
+
     public static Throwable findRootCause(Throwable t) {
-        if(t.getCause() == null) return t;
+        if (t.getCause() == null)
+            return t;
         return findRootCause(t.getCause());
     }
 }

--- a/src/test/java/amqp/spring/camel/component/SpringAMQPComponentTest.java
+++ b/src/test/java/amqp/spring/camel/component/SpringAMQPComponentTest.java
@@ -4,6 +4,7 @@
 package amqp.spring.camel.component;
 
 import junit.framework.Assert;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
 import org.apache.camel.test.junit4.CamelTestSupport;
@@ -12,13 +13,18 @@ import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 
 public class SpringAMQPComponentTest extends CamelTestSupport {
-    
+
     @Test
     public void testCreateContext() throws Exception {
-        Component component = context().getComponent("spring-amqp", SpringAMQPComponent.class);
+        Component component = context().getComponent(SpringAMQPComponent.DEFAULT_SCHEME, SpringAMQPComponent.class);
         Assert.assertNotNull(component);
     }
-    
+
+    @Test
+    public void testDefaultScheme() throws Exception {
+        Assert.assertEquals(SpringAMQPComponent.DEFAULT_SCHEME, new SpringAMQPComponent().getScheme());
+    }
+
     @Test
     public void testFindRootCause() throws Exception {
         IllegalStateException child = new IllegalStateException("Child Exception");
@@ -26,13 +32,13 @@ public class SpringAMQPComponentTest extends CamelTestSupport {
         RuntimeException grandparent = new RuntimeException("Grandparent Exception", parent);
         Assert.assertEquals(child, SpringAMQPComponent.findRootCause(grandparent));
     }
-    
+
     @Override
     protected CamelContext createCamelContext() throws Exception {
         ConnectionFactory factory = new CachingConnectionFactory();
-        
+
         CamelContext camelContext = super.createCamelContext();
-        camelContext.addComponent("spring-amqp", new SpringAMQPComponent(factory));
+        camelContext.addComponent(SpringAMQPComponent.DEFAULT_SCHEME, new SpringAMQPComponent(factory));
         return camelContext;
     }
 }

--- a/src/test/java/amqp/spring/camel/component/SpringAMQPConsumerTest.java
+++ b/src/test/java/amqp/spring/camel/component/SpringAMQPConsumerTest.java
@@ -6,8 +6,8 @@ package amqp.spring.camel.component;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.sun.org.apache.bcel.internal.generic.ExceptionThrower;
 import junit.framework.Assert;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
 import org.apache.camel.Consumer;
@@ -24,40 +24,48 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.JsonMessageConverter;
 
 public class SpringAMQPConsumerTest extends CamelTestSupport {
-    
+
     @Test
     public void testCreateContext() throws Exception {
-        Component component = context().getComponent("spring-amqp", SpringAMQPComponent.class);
+        Component component = context().getComponent(SpringAMQPComponent.DEFAULT_SCHEME, SpringAMQPComponent.class);
         Assert.assertNotNull(component);
     }
-    
-    @Test 
+
+    @Test
     public void restartConsumer() throws Exception {
         Processor defaultProcessor = new Processor() {
             @Override
-            public void process(Exchange exchange) throws Exception { }
+            public void process(Exchange exchange) throws Exception {
+            }
         };
-        
-        Consumer amqpConsumer = context().getEndpoint("spring-amqp:directExchange:q0:test.a?durable=false&autodelete=true&exclusive=false&ha=true").createConsumer(defaultProcessor);
+
+        Consumer amqpConsumer = context().getEndpoint(
+                SpringAMQPComponent.DEFAULT_SCHEME
+                        + ":directExchange:q0:test.a?durable=false&autodelete=true&exclusive=false&ha=true")
+                .createConsumer(defaultProcessor);
         amqpConsumer.stop();
         amqpConsumer.start();
     }
-    
-    @Test 
+
+    @Test
     public void disconnectConsumer() throws Exception {
         Processor defaultProcessor = new Processor() {
             @Override
-            public void process(Exchange exchange) throws Exception { }
+            public void process(Exchange exchange) throws Exception {
+            }
         };
-        
-        SpringAMQPConsumer amqpConsumer = (SpringAMQPConsumer) context().getEndpoint("spring-amqp:directExchange:q0:test.a?durable=false&autodelete=true&exclusive=false").createConsumer(defaultProcessor);
+
+        SpringAMQPConsumer amqpConsumer = (SpringAMQPConsumer) context().getEndpoint(
+                SpringAMQPComponent.DEFAULT_SCHEME
+                        + ":directExchange:q0:test.a?durable=false&autodelete=true&exclusive=false").createConsumer(
+                defaultProcessor);
         amqpConsumer.onClose(null);
         amqpConsumer.onCreate(null);
     }
-    
+
     @Test
     public void testKeyValueParsing() throws Exception {
-        Map<String, Object> keyValues = SpringAMQPConsumer.parseKeyValues("cheese=gouda&fromage=jack");
+        Map < String, Object > keyValues = SpringAMQPConsumer.parseKeyValues("cheese=gouda&fromage=jack");
         Assert.assertEquals("gouda", keyValues.get("cheese"));
         Assert.assertEquals("jack", keyValues.get("fromage"));
 
@@ -70,84 +78,101 @@ public class SpringAMQPConsumerTest extends CamelTestSupport {
     public void sendMessage() throws Exception {
         MockEndpoint mockEndpoint = getMockEndpoint("mock:test.a");
         mockEndpoint.expectedMessageCount(1);
-        context().createProducerTemplate().sendBodyAndHeader("spring-amqp:directExchange:test.a?durable=false&autodelete=true&exclusive=false", "sendMessage", "HeaderKey", "HeaderValue");
-        
+        context().createProducerTemplate().sendBodyAndHeader(
+                SpringAMQPComponent.DEFAULT_SCHEME
+                        + ":directExchange:test.a?durable=false&autodelete=true&exclusive=false", "sendMessage",
+                "HeaderKey", "HeaderValue");
+
         mockEndpoint.assertIsSatisfied();
         Message inMessage = mockEndpoint.getExchanges().get(0).getIn();
         Assert.assertEquals("sendMessage", inMessage.getBody(String.class));
         Assert.assertEquals("HeaderValue", inMessage.getHeader("HeaderKey"));
         Assert.assertNotNull(inMessage.getMessageId());
     }
-    
+
     @Test
     public void sendAsyncMessage() throws Exception {
         MockEndpoint mockEndpoint = getMockEndpoint("mock:test.b");
         mockEndpoint.expectedMessageCount(1);
-        context().createProducerTemplate().asyncRequestBodyAndHeader("spring-amqp:directExchange:test.b?durable=false&autodelete=true&exclusive=false", "sendMessage", "HeaderKey", "HeaderValue");
-        
+        context().createProducerTemplate().asyncRequestBodyAndHeader(
+                SpringAMQPComponent.DEFAULT_SCHEME
+                        + ":directExchange:test.b?durable=false&autodelete=true&exclusive=false", "sendMessage",
+                "HeaderKey", "HeaderValue");
+
         mockEndpoint.assertIsSatisfied();
         Message inMessage = mockEndpoint.getExchanges().get(0).getIn();
         Assert.assertEquals("sendMessage", inMessage.getBody(String.class));
         Assert.assertEquals("HeaderValue", inMessage.getHeader("HeaderKey"));
         Assert.assertNotNull(inMessage.getMessageId());
     }
-    
+
     @Test
     public void testHeaderAndExchange() throws Exception {
         MockEndpoint mockEndpointOne = getMockEndpoint("mock:test.b");
         mockEndpointOne.expectedMessageCount(1);
-        
-        Map<String, Object> headersOne = new HashMap<String, Object>();
+
+        Map < String, Object > headersOne = new HashMap < String, Object >();
         headersOne.put("cheese", "asiago");
         headersOne.put("fromage", "cheddar");
-        context().createProducerTemplate().sendBodyAndHeaders("spring-amqp:headerAndExchange?type=headers", "testHeaderExchange", headersOne);
-        
+        context().createProducerTemplate().sendBodyAndHeaders(
+                SpringAMQPComponent.DEFAULT_SCHEME + ":headerAndExchange?type=headers", "testHeaderExchange",
+                headersOne);
+
         MockEndpoint mockEndpointTwo = context().getEndpoint("mock:test.c", MockEndpoint.class);
         mockEndpointTwo.expectedMessageCount(1);
-        
-        Map<String, Object> headersTwo = new HashMap<String, Object>();
+
+        Map < String, Object > headersTwo = new HashMap < String, Object >();
         headersTwo.put("cheese", "gouda");
         headersTwo.put("fromage", "jack");
-        context().createProducerTemplate().sendBodyAndHeaders("spring-amqp:headerAndExchange?type=headers", "testHeaderExchange", headersTwo);
-        
+        context().createProducerTemplate().sendBodyAndHeaders(
+                SpringAMQPComponent.DEFAULT_SCHEME + ":headerAndExchange?type=headers", "testHeaderExchange",
+                headersTwo);
+
         mockEndpointOne.assertIsSatisfied();
         mockEndpointTwo.assertIsSatisfied();
     }
-    
+
     @Test
     public void testHeaderOrExchange() throws Exception {
         MockEndpoint mockEndpointOne = getMockEndpoint("mock:test.d");
         mockEndpointOne.expectedMessageCount(2);
-        
-        Map<String, Object> headersOne = new HashMap<String, Object>();
+
+        Map < String, Object > headersOne = new HashMap < String, Object >();
         headersOne.put("cheese", "asiago");
         headersOne.put("fromage", "bleu");
-        context().createProducerTemplate().sendBodyAndHeaders("spring-amqp:headerOrExchange?type=headers", "testHeaderExchange", headersOne);
-        
-        Map<String, Object> headersTwo = new HashMap<String, Object>();
+        context().createProducerTemplate()
+                .sendBodyAndHeaders(SpringAMQPComponent.DEFAULT_SCHEME + ":headerOrExchange?type=headers",
+                        "testHeaderExchange", headersOne);
+
+        Map < String, Object > headersTwo = new HashMap < String, Object >();
         headersTwo.put("cheese", "white");
         headersTwo.put("fromage", "jack");
-        context().createProducerTemplate().sendBodyAndHeaders("spring-amqp:headerOrExchange?type=headers", "testHeaderExchange", headersTwo);
-        
+        context().createProducerTemplate()
+                .sendBodyAndHeaders(SpringAMQPComponent.DEFAULT_SCHEME + ":headerOrExchange?type=headers",
+                        "testHeaderExchange", headersTwo);
+
         mockEndpointOne.assertIsSatisfied();
     }
-    
+
     @Test
     public void testDefaultExchange() throws Exception {
         MockEndpoint mockEndpointOne = getMockEndpoint("mock:test.e");
         mockEndpointOne.expectedMessageCount(1);
-        
-        context().createProducerTemplate().sendBody("spring-amqp::test.e", "testBody");
-        
+
+        context().createProducerTemplate().sendBody(SpringAMQPComponent.DEFAULT_SCHEME + "::test.e", "testBody");
+
         mockEndpointOne.assertIsSatisfied();
     }
-    
+
     @Test
     public void sendMessageTTL() throws Exception {
         MockEndpoint mockEndpoint = getMockEndpoint("mock:test.a");
         mockEndpoint.expectedMessageCount(1);
-        context().createProducerTemplate().sendBodyAndHeader("spring-amqp:directExchange:test.a?durable=false&autodelete=true&exclusive=false&timeToLive=1000", "sendMessage", "HeaderKey", "HeaderValue");
-        
+        context().createProducerTemplate().sendBodyAndHeader(
+                SpringAMQPComponent.DEFAULT_SCHEME
+                        + ":directExchange:test.a?durable=false&autodelete=true&exclusive=false&timeToLive=1000",
+                "sendMessage", "HeaderKey", "HeaderValue");
+
         mockEndpoint.assertIsSatisfied();
         Message inMessage = mockEndpoint.getExchanges().get(0).getIn();
         Assert.assertEquals("sendMessage", inMessage.getBody(String.class));
@@ -157,7 +182,8 @@ public class SpringAMQPConsumerTest extends CamelTestSupport {
     @Test
     public void testHandleException() {
         try {
-            Object result = context().createProducerTemplate().requestBody("spring-amqp::test.f", "testBody");
+            Object result = context().createProducerTemplate().requestBody(
+                    SpringAMQPComponent.DEFAULT_SCHEME + "::test.f", "testBody");
             Assert.fail("Should have thrown exception up to caller but received object: " + result);
         } catch (RuntimeException e) {
             // success
@@ -175,13 +201,13 @@ public class SpringAMQPConsumerTest extends CamelTestSupport {
     protected CamelContext createCamelContext() throws Exception {
         CachingConnectionFactory factory = new CachingConnectionFactory();
         RabbitTemplate amqpTemplate = new RabbitTemplate(factory);
-        //The JSON converter stresses marshalling more than the default converter
+        // The JSON converter stresses marshalling more than the default converter
         amqpTemplate.setMessageConverter(new JsonMessageConverter());
         SpringAMQPComponent amqpComponent = new SpringAMQPComponent(factory);
         amqpComponent.setAmqpTemplate(amqpTemplate);
-        
+
         CamelContext camelContext = super.createCamelContext();
-        camelContext.addComponent("spring-amqp", amqpComponent);
+        camelContext.addComponent(SpringAMQPComponent.DEFAULT_SCHEME, amqpComponent);
         return camelContext;
     }
 
@@ -190,15 +216,34 @@ public class SpringAMQPConsumerTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-                from("spring-amqp:directExchange:q1:test.a?durable=false&autodelete=true&exclusive=false").to("mock:test.a");
-                from("spring-amqp:directExchange:q5:test.b?durable=false&autodelete=true&exclusive=false").to("mock:test.b");
-                from("spring-amqp:headerAndExchange:q2:cheese=asiago&fromage=cheddar?type=headers&durable=false&autodelete=true&exclusive=false").to("mock:test.b");
-                from("spring-amqp:headerAndExchange:q3:cheese=gouda&fromage=jack?type=headers&durable=false&autodelete=true&exclusive=false").to("mock:test.c");
-                from("spring-amqp:headerOrExchange:q4:cheese=white|fromage=bleu?type=headers&durable=false&autodelete=true&exclusive=false").to("mock:test.d");
-                from("spring-amqp::test.e:test.e?durable=false&autodelete=true&exclusive=false").to("mock:test.e");
-                from("spring-amqp::test.f:test.f?durable=false&autodelete=true&exclusive=false").beanRef("exceptionThrower", "explode");
+                from(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + ":directExchange:q1:test.a?durable=false&autodelete=true&exclusive=false").to(
+                        "mock:test.a");
+                from(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + ":directExchange:q5:test.b?durable=false&autodelete=true&exclusive=false").to(
+                        "mock:test.b");
+                from(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + ":headerAndExchange:q2:cheese=asiago&fromage=cheddar?type=headers&durable=false&autodelete=true&exclusive=false")
+                        .to("mock:test.b");
+                from(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + ":headerAndExchange:q3:cheese=gouda&fromage=jack?type=headers&durable=false&autodelete=true&exclusive=false")
+                        .to("mock:test.c");
+                from(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + ":headerOrExchange:q4:cheese=white|fromage=bleu?type=headers&durable=false&autodelete=true&exclusive=false")
+                        .to("mock:test.d");
+                from(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + "::test.e:test.e?durable=false&autodelete=true&exclusive=false").to("mock:test.e");
+                from(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + "::test.f:test.f?durable=false&autodelete=true&exclusive=false").beanRef(
+                        "exceptionThrower", "explode");
             }
         };
     }
 }
-

--- a/src/test/java/amqp/spring/camel/component/SpringAMQPEndpointTest.java
+++ b/src/test/java/amqp/spring/camel/component/SpringAMQPEndpointTest.java
@@ -3,7 +3,11 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 package amqp.spring.camel.component;
 
-import org.apache.camel.*;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Component;
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Assert;
 import org.junit.Test;
@@ -12,101 +16,122 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class SpringAMQPEndpointTest extends CamelTestSupport {
-    
+
     @Test
     public void testCreateContext() throws Exception {
-        Component component = context().getComponent("spring-amqp", SpringAMQPComponent.class);
+        Component component = context().getComponent(SpringAMQPComponent.DEFAULT_SCHEME, SpringAMQPComponent.class);
         Assert.assertNotNull(component);
-        
-        Endpoint endpoint = component.createEndpoint("spring-amqp:test.a");
+
+        Endpoint endpoint = component.createEndpoint(SpringAMQPComponent.DEFAULT_SCHEME + ":test.a");
         Assert.assertNotNull(endpoint);
     }
-    
+
     @Test
     public void testUriParsingOfDefaultExchangeWithQueueAndRoutingKeyForConsumer() {
-        Component component = context().getComponent("spring-amqp", SpringAMQPComponent.class);
-    	String remaining = ":queue1:routingKey1";
-        String uri = "spring-amqp:"+remaining;
-    	
-    	SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
-    	
-    	Assert.assertEquals("", endpoint.exchangeName);
-    	Assert.assertEquals("queue1", endpoint.queueName);
-    	Assert.assertEquals("routingKey1", endpoint.routingKey);
+        Component component = context().getComponent(SpringAMQPComponent.DEFAULT_SCHEME, SpringAMQPComponent.class);
+        String remaining = ":queue1:routingKey1";
+        String uri = SpringAMQPComponent.DEFAULT_SCHEME + ":" + remaining;
+
+        SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
+
+        Assert.assertEquals("", endpoint.exchangeName);
+        Assert.assertEquals("queue1", endpoint.queueName);
+        Assert.assertEquals("routingKey1", endpoint.routingKey);
     }
-    
+
     @Test
     public void testUriParsingOfDefaultExchangeWithRoutingKeyForProducer() {
-        Component component = context().getComponent("spring-amqp", SpringAMQPComponent.class);
+        Component component = context().getComponent(SpringAMQPComponent.DEFAULT_SCHEME, SpringAMQPComponent.class);
         String remaining = ":routingKey1";
-        String uri = "spring-amqp:"+remaining;
-    	
-    	SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
-    	
-    	Assert.assertEquals("", endpoint.exchangeName);
-    	Assert.assertEquals("routingKey1", ReflectionTestUtils.getField(endpoint, "tempQueueOrKey"));
+        String uri = SpringAMQPComponent.DEFAULT_SCHEME + ":" + remaining;
+
+        SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
+
+        Assert.assertEquals("", endpoint.exchangeName);
+        Assert.assertEquals("routingKey1", ReflectionTestUtils.getField(endpoint, "tempQueueOrKey"));
     }
-    
+
     @Test
     public void testIsUsingDefaultExchangeTrue() {
-        Component component = context().getComponent("spring-amqp", SpringAMQPComponent.class);
+        Component component = context().getComponent(SpringAMQPComponent.DEFAULT_SCHEME, SpringAMQPComponent.class);
         String remaining = ":routingKey1";
-        String uri = "spring-amqp:"+remaining;
-    	
-    	SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
-    	
-    	Assert.assertTrue(endpoint.isUsingDefaultExchange());
+        String uri = SpringAMQPComponent.DEFAULT_SCHEME + ":" + remaining;
+
+        SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
+
+        Assert.assertTrue(endpoint.isUsingDefaultExchange());
     }
-    
+
     @Test
     public void testIsNotUsingDefaultExchangeFalse() {
-        Component component = context().getComponent("spring-amqp", SpringAMQPComponent.class);
+        Component component = context().getComponent(SpringAMQPComponent.DEFAULT_SCHEME, SpringAMQPComponent.class);
         String remaining = "exchange1:routingKey1";
-        String uri = "spring-amqp:"+remaining;
-    	
-    	SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
-    	
-    	Assert.assertFalse(endpoint.isUsingDefaultExchange());
-    }    
-        
+        String uri = SpringAMQPComponent.DEFAULT_SCHEME + ":" + remaining;
+
+        SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
+
+        Assert.assertFalse(endpoint.isUsingDefaultExchange());
+    }
+
     @Test
     public void testDefaultFanoutConsumer() throws Exception {
         Processor defaultProcessor = new Processor() {
             @Override
-            public void process(Exchange exchange) throws Exception { }
+            public void process(Exchange exchange) throws Exception {
+            }
         };
 
-        Component component = context().getComponent("spring-amqp", SpringAMQPComponent.class);
+        Component component = context().getComponent(SpringAMQPComponent.DEFAULT_SCHEME, SpringAMQPComponent.class);
         String remaining = "exchange2:queue2";
-        String uri = "spring-amqp:"+remaining;
-    	
-    	SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
+        String uri = SpringAMQPComponent.DEFAULT_SCHEME + ":" + remaining;
+
+        SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
         endpoint.createConsumer(defaultProcessor);
-    	
-        //If you specify an exchange and queue but nothing else, this should be a fanout exchange
-    	Assert.assertEquals("queue2", endpoint.getQueueName());
+
+        // If you specify an exchange and queue but nothing else, this should be a fanout exchange
+        Assert.assertEquals("queue2", endpoint.getQueueName());
         Assert.assertEquals("exchange2", endpoint.getExchangeName());
         Assert.assertEquals("fanout", endpoint.getType());
     }
-    
+
     @Test
     public void testHashDelimiters() {
-        Component component = context().getComponent("spring-amqp", SpringAMQPComponent.class);
+        Component component = context().getComponent(SpringAMQPComponent.DEFAULT_SCHEME, SpringAMQPComponent.class);
         String remaining = "exchange1:#.routingKey1.#";
-        String uri = "spring-amqp:"+remaining;
-    	
-    	SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
-    	
-        //Ensure things can be printed correctly; setEndpoint(String) has had issues previously
-    	Assert.assertNotNull(endpoint.toString());
-    }    
-        
+        String uri = SpringAMQPComponent.DEFAULT_SCHEME + ":" + remaining;
+
+        SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
+
+        // Ensure things can be printed correctly; setEndpoint(String) has had issues previously
+        Assert.assertNotNull(endpoint.toString());
+    }
+
+    @Test
+    public void testEndpointUriUseComponentScheme() throws Exception {
+        // Given
+        SpringAMQPComponent component = new SpringAMQPComponent();
+        String cutomScheme = "amqp-broker-0";
+        component.setScheme(cutomScheme);
+        context.addComponent(cutomScheme, component);
+
+        String remaining = "exchange1:#.routingKey1.#";
+        String uri = new StringBuilder(cutomScheme).append(":").append(remaining).toString();
+        SpringAMQPEndpoint endpoint = new SpringAMQPEndpoint(component, uri, remaining, null, null);
+
+        // When
+        String createdUri = endpoint.createEndpointUri();
+
+        // Then
+        Assert.assertTrue(createdUri.startsWith(cutomScheme));
+
+    }
+
     @Override
     protected CamelContext createCamelContext() throws Exception {
         ConnectionFactory factory = new CachingConnectionFactory();
-        
+
         CamelContext camelContext = super.createCamelContext();
-        camelContext.addComponent("spring-amqp", new SpringAMQPComponent(factory));
+        camelContext.addComponent(SpringAMQPComponent.DEFAULT_SCHEME, new SpringAMQPComponent(factory));
         return camelContext;
     }
 }

--- a/src/test/java/amqp/spring/camel/component/SpringAMQPProducerTest.java
+++ b/src/test/java/amqp/spring/camel/component/SpringAMQPProducerTest.java
@@ -4,7 +4,9 @@
 package amqp.spring.camel.component;
 
 import java.io.Serializable;
+
 import junit.framework.Assert;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
 import org.apache.camel.Exchange;
@@ -18,30 +20,32 @@ import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 
 public class SpringAMQPProducerTest extends CamelTestSupport {
-    
+
     @Test
     public void testCreateContext() throws Exception {
-        Component component = context().getComponent("spring-amqp", SpringAMQPComponent.class);
+        Component component = context().getComponent(SpringAMQPComponent.DEFAULT_SCHEME, SpringAMQPComponent.class);
         Assert.assertNotNull(component);
     }
-    
-    @Test 
+
+    @Test
     public void restartProducer() throws Exception {
-        Producer producer = context().getEndpoint("spring-amqp:fanoutExchange?durable=false&autodelete=true&exclusive=false").createProducer();
+        Producer producer = context().getEndpoint(
+                SpringAMQPComponent.DEFAULT_SCHEME + ":fanoutExchange?durable=false&autodelete=true&exclusive=false")
+                .createProducer();
         producer.start();
         producer.stop();
     }
-    
+
     @Test
     public void sendMessage() throws Exception {
         context().createProducerTemplate().sendBody("direct:test.z", "HELLO WORLD");
     }
-    
+
     @Test
     public void sendAsyncMessage() throws Exception {
         context().createProducerTemplate().asyncRequestBody("direct:test.x", "HELLO WORLD");
     }
-    
+
     @Test
     public void sendAsyncCallbackMessage() throws Exception {
         context().createProducerTemplate().asyncCallbackSendBody("direct:test.w", "HELLO WORLD", new Synchronization() {
@@ -52,34 +56,36 @@ public class SpringAMQPProducerTest extends CamelTestSupport {
 
             @Override
             public void onFailure(Exchange exchange) {
-                Assert.fail(exchange.getException() != null ? exchange.getException().getMessage() : "Failure on async callback");
+                Assert.fail(exchange.getException() != null ? exchange.getException().getMessage()
+                        : "Failure on async callback");
             }
         });
     }
-    
+
     @Test
     public void sendObject() throws Exception {
         context().createProducerTemplate().sendBody("direct:test.z", new ProducerTestObject());
     }
-    
+
     @Test
     public void sendNull() throws Exception {
         context().createProducerTemplate().sendBody("direct:test.z", null);
     }
-    
+
     @Test
     public void sendUsingDefaultExchange() throws Exception {
         context().createProducerTemplate().sendBody("direct:test.y", null);
     }
-    
+
     @Test
     public void headerRoutingKey() throws Exception {
         MockEndpoint mockEndpoint = getMockEndpoint("mock:test.v");
         mockEndpoint.expectedMessageCount(1);
-        context().createProducerTemplate().sendBodyAndHeader("direct:test.v", new ProducerTestObject(), SpringAMQPComponent.ROUTING_KEY_HEADER, "test.v");
+        context().createProducerTemplate().sendBodyAndHeader("direct:test.v", new ProducerTestObject(),
+                SpringAMQPComponent.ROUTING_KEY_HEADER, "test.v");
         mockEndpoint.assertIsSatisfied();
     }
-    
+
     @Test
     public void uriRoutingKey() throws Exception {
         MockEndpoint mockEndpoint = getMockEndpoint("mock:test.u");
@@ -87,37 +93,54 @@ public class SpringAMQPProducerTest extends CamelTestSupport {
         context().createProducerTemplate().sendBody("direct:test.u", new ProducerTestObject());
         mockEndpoint.assertIsSatisfied();
     }
-    
+
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CachingConnectionFactory factory = new CachingConnectionFactory();
         RabbitTemplate amqpTemplate = new RabbitTemplate(factory);
         SpringAMQPComponent amqpComponent = new SpringAMQPComponent(factory);
         amqpComponent.setAmqpTemplate(amqpTemplate);
-        
+
         CamelContext camelContext = super.createCamelContext();
-        camelContext.addComponent("spring-amqp", amqpComponent);
+        camelContext.addComponent(SpringAMQPComponent.DEFAULT_SCHEME, amqpComponent);
         return camelContext;
     }
-    
+
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-            	from("direct:test.y").to("spring-amqp::?durable=false&autodelete=true&exclusive=false");
-                from("direct:test.z").to("spring-amqp:fanoutExchange?durable=false&autodelete=true&exclusive=false");
-                from("direct:test.x").to("spring-amqp:fanoutExchange?durable=false&autodelete=true&exclusive=false");
-                from("direct:test.w").to("spring-amqp:fanoutExchange?durable=false&autodelete=true&exclusive=false");
-                from("direct:test.v").to("spring-amqp:topicExchange?type=topic&durable=false&autodelete=true&exclusive=false");
-                from("direct:test.u").to("spring-amqp:topicExchange:test.u?durable=false&autodelete=true&exclusive=false");
-                
-                from("spring-amqp:topicExchange:queue.v:#.v?type=topic&durable=false&type=direct&autodelete=true&exclusive=false").to("mock:test.v");
-                from("spring-amqp:topicExchange:queue.u:#.u?type=topic&durable=false&type=direct&autodelete=true&exclusive=false").to("mock:test.u");
+                from("direct:test.y").to(
+                        SpringAMQPComponent.DEFAULT_SCHEME + "::?durable=false&autodelete=true&exclusive=false");
+                from("direct:test.z").to(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + ":fanoutExchange?durable=false&autodelete=true&exclusive=false");
+                from("direct:test.x").to(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + ":fanoutExchange?durable=false&autodelete=true&exclusive=false");
+                from("direct:test.w").to(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + ":fanoutExchange?durable=false&autodelete=true&exclusive=false");
+                from("direct:test.v").to(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + ":topicExchange?type=topic&durable=false&autodelete=true&exclusive=false");
+                from("direct:test.u").to(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + ":topicExchange:test.u?durable=false&autodelete=true&exclusive=false");
+
+                from(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + ":topicExchange:queue.v:#.v?type=topic&durable=false&type=direct&autodelete=true&exclusive=false")
+                        .to("mock:test.v");
+                from(
+                        SpringAMQPComponent.DEFAULT_SCHEME
+                                + ":topicExchange:queue.u:#.u?type=topic&durable=false&type=direct&autodelete=true&exclusive=false")
+                        .to("mock:test.u");
             }
         };
     }
-    
+
     public static class ProducerTestObject implements Serializable {
         private static final long serialVersionUID = -9121162751092118857L;
         private String test;


### PR DESCRIPTION
Hi guys, that's really a great job you've done there.
I had the need to address more than one broker in my app and in a dynamic way, so I thought the easiest way was to create and declare in camel context one SpringAMQPComponent (with its own connection factory) per broker instance and thus with its specific scheme (spring-amqp-xx:etc.) 
I then realized that Camel was using the endpoint#createEndpointUri wich was ignoring the specific scheme I had set preventing camel context to start because of falsy doubled endpoint definitions (see equals in DefaultEndpoint).
I would be glad if you could merge in my modifications or propose some other way to do it (overriding AmqpTemplate and Admin at endpoint level from uri maybe ?)
Regards.
