### PR TITLE
Not storing Camel message header values twice in converted AMQP message

### DIFF
--- a/src/main/java/amqp/spring/camel/component/SpringAMQPHeader.java
+++ b/src/main/java/amqp/spring/camel/component/SpringAMQPHeader.java
@@ -65,7 +65,16 @@ public class SpringAMQPHeader {
     
     public static Message copyHeaders(Message msg, Map<String, Object> headers) {
         for(Map.Entry<String, Object> headerEntry : headers.entrySet()) {
-            if(! msg.getMessageProperties().getHeaders().containsKey(headerEntry.getKey())) {
+            // headers used for setting basic properties and routing key are skipped
+            if( !CONTENT_ENCODING.equals(headerEntry.getKey()) &&
+                    !CONTENT_TYPE.equals(headerEntry.getKey()) &&
+                    !CORRELATION_ID.equals(headerEntry.getKey()) &&
+                    !EXPIRATION.equals(headerEntry.getKey()) &&
+                    !PRIORITY.equals(headerEntry.getKey()) &&
+                    !REPLY_TO.equals(headerEntry.getKey()) &&
+                    !TYPE.equals(headerEntry.getKey()) &&
+                    !SpringAMQPComponent.ROUTING_KEY_HEADER.equals(headerEntry.getKey()) &&
+                    !msg.getMessageProperties().getHeaders().containsKey(headerEntry.getKey())) {
                 msg.getMessageProperties().setHeader(headerEntry.getKey(), headerEntry.getValue());
             }
         }


### PR DESCRIPTION
Camel message headers used for setting basic AMQP message properties and routing key are no longer copied also to AMQP message headers.
