### PR TITLE
procedure of finding identical connections at amqp.spring.camel.componen...

### DIFF
--- a/src/main/java/amqp/spring/camel/component/SpringAMQPComponent.java
+++ b/src/main/java/amqp/spring/camel/component/SpringAMQPComponent.java
@@ -91,7 +91,7 @@ public class SpringAMQPComponent extends DefaultComponent {
             for(AmqpAdmin admin : adminMap.values()){
                 CachingConnectionFactory adminConnection = (CachingConnectionFactory)((RabbitAdmin)admin).getRabbitTemplate().getConnectionFactory();
                 for(Map.Entry<String, ConnectionFactory> connection : this.connectionFactory.entrySet()){
-                    if(adminConnection.getHost().equals(connection.getValue().getHost()) && adminConnection.getPort() == (connection.getValue().getPort())){
+                    if(identicalConnectionFactories(adminConnection, connection.getValue())){
                         this.amqpAdministration.put(connection.getKey(), admin);
                         break;
                     }
@@ -130,7 +130,7 @@ public class SpringAMQPComponent extends DefaultComponent {
             for(AmqpTemplate template : templateMap.values()){
                 CachingConnectionFactory adminConnection = (CachingConnectionFactory)((RabbitTemplate) template).getConnectionFactory();
                 for(Map.Entry<String, ConnectionFactory> connection : this.connectionFactory.entrySet()){
-                    if(adminConnection.getHost().equals(connection.getValue().getHost()) && adminConnection.getPort() == (connection.getValue().getPort())){
+                    if(identicalConnectionFactories(adminConnection, connection.getValue())){
                         this.amqpTemplate.put(connection.getKey(), template);
                         break;
                     }
@@ -164,6 +164,13 @@ public class SpringAMQPComponent extends DefaultComponent {
     public static Throwable findRootCause(Throwable t) {
         if(t.getCause() == null) return t;
         return findRootCause(t.getCause());
+    }
+
+    private boolean identicalConnectionFactories(ConnectionFactory cf, ConnectionFactory candidateCF) {
+      String host = candidateCF.getHost();
+      String vhost = candidateCF.getVirtualHost();
+      int port = candidateCF.getPort();
+      return cf.getHost().equals(host) && cf.getVirtualHost().equals(vhost) && cf.getPort() == port;
     }
 }
 


### PR DESCRIPTION
procedure of finding identical connections at amqp.spring.camel.component.SpringAMQPComponent#getAmqpAdministration and amqp.spring.camel.component.SpringAMQPComponent#getAmqpTemplate should use host port and virtualHost.
in my case i have several virtual hosts for different integration fields. 
