### PR TITLE
Updated project dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,11 +66,13 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <org.apache.camel.version>2.13.2</org.apache.camel.version>
-        <org.springframework.amqp.version>1.3.4.RELEASE</org.springframework.amqp.version>
-        <org.springframework.retry.version>1.1.0.RELEASE</org.springframework.retry.version>
-        <!-- Keep this in line with the version referenced by Camel and Spring-AMQP -->
-        <org.springframework.version>3.2.8.RELEASE</org.springframework.version>
+        <!-- Camel 2.14 drops support for Java 1.6 so we stay with 2.13 for now -->
+        <org.apache.camel.version>2.13.3</org.apache.camel.version>
+        <!-- Spring AMQP 1.4 uses Spring 4.1 which is not supported by Camel 2.13 so we stay with 1.3 for now -->
+        <org.springframework.amqp.version>1.3.7.RELEASE</org.springframework.amqp.version>
+        <org.springframework.retry.version>1.1.2.RELEASE</org.springframework.retry.version>
+        <!-- Keep this in line with the version referenced by Camel and Spring-AMQP versions in use (3.2.11 and 3.2.9) -->
+        <org.springframework.version>3.2.11.RELEASE</org.springframework.version>
         <ch.qos.logback.version>1.1.2</ch.qos.logback.version>
     </properties>
 
@@ -84,7 +86,7 @@
         <dependency>
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
-            <version>1.3.5</version>
+            <version>1.3.7</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
@@ -201,7 +203,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.2</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
@@ -211,7 +213,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
+                <version>2.9</version>
                 <executions>
                     <execution>
                         <id>install</id>
@@ -225,12 +227,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>2.10.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>2.4</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -243,7 +245,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.4</version>
                 <configuration>
                     <reportPlugins>
                         <plugin>


### PR DESCRIPTION
Most importantly, Camel updated from 2.13.2 to 2.13.3 and spring-amqp from 1.3.4 to 1.3.7. These are the latest versions that can be used without dropping support for Java 6 as explained in comments in pom.xml.